### PR TITLE
Hotfix - DAG Obfuscation default function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "telescope"
-version = "2.0.3"
+version = "2.0.3-1"
 description = "A tool to observe distant (or local!) Airflow installations, and gather metadata or other required data."
 readme = "README.md"
 authors = ["telescope <solutions@astronomer.io>"]

--- a/telescope/__main__.py
+++ b/telescope/__main__.py
@@ -137,7 +137,7 @@ def cli(
     # Check for helm secrets or get cluster info if we know we are running with Kubernetes
     if any(type(g) == KubernetesGetter for g in all_getters):
         helm_spinner = Halo(
-            text=f"Verifying helm chart info",
+            text="Verifying helm chart info",
             spinner="dots",
         )
         helm_spinner.start()
@@ -145,12 +145,12 @@ def cli(
             data["verify"] = get_helm_info()
             helm_spinner.succeed()
         except Exception as e:
-            helm_spinner.warn(f"verifying helm info failed")
+            helm_spinner.warn("verifying helm info failed")
             log.debug(e)
             data["verify"] = {"error": str(e)}
 
         cluster_spinner = Halo(
-            text=f"Gathering cluster info",
+            text="Gathering cluster info",
             spinner="dots",
         )
         cluster_spinner.start()
@@ -158,7 +158,7 @@ def cli(
             data["cluster_info"] = cluster_info()
             cluster_spinner.succeed()
         except Exception as e:
-            cluster_spinner.warn(f"gathering cluster info failed")
+            cluster_spinner.warn("gathering cluster info failed")
             log.debug(e)
             data["cluster_info"] = {"error": str(e)}
 

--- a/telescope/getters/local.py
+++ b/telescope/getters/local.py
@@ -22,7 +22,7 @@ class LocalGetter(Getter):
         out = run(cmd, hide=True, warn=True)  # other options: timeout, warn
         if out.stdout:
             out = clean_airflow_report_output(out.stdout)
-        elif out.stderr_bytes is not None:
+        elif out.stderr is not None:
             out = out.stderr
         else:
             out = "Unknown Error"

--- a/tests/resources/slowtest_dev.sh
+++ b/tests/resources/slowtest_dev.sh
@@ -4,11 +4,13 @@ rm -rf dev
 virtualenv dev
 source  dev/bin/activate
 set -x
-python -m pip install telescope poetry --find-links https://github.com/astronomer/telescope/releases/
+python -m pip install telescope poetry --find-links https://github.com/astronomer/telescope/releases/tag/v$(poetry version --short)
 
-TELESCOPE_REPORT_RELEASE_VERSION=$(poetry version --short) telescope --kubernetes --docker --local
+LOG_LEVEL=DEBUG TELESCOPE_REPORT_RELEASE_VERSION=$(poetry version --short) telescope --kubernetes --docker --local -n Astronomer
 
-TELESCOPE_KUBERNETES_METHOD=kubectl TELESCOPE_REPORT_RELEASE_VERSION=$(poetry version --short) telescope --kubernetes
+LOG_LEVEL=DEBUG TELESCOPE_KUBERNETES_METHOD=kubectl TELESCOPE_REPORT_RELEASE_VERSION=$(poetry version --short) telescope --kubernetes -n Astronomer
+
+LOG_LEVEL=DEBUG TELESCOPE_REPORT_RELEASE_VERSION=$(poetry version --short) telescope --kubernetes --dag-obfuscation -n Astronomer
 
 set +x
 deactivate


### PR DESCRIPTION
Missed defaulting the `dag_obfuscation_fn` if it's passed in as `None`
Also moved around logging to account for other run modes (e.g. if it isn't `Kubernetes`, `namespace` doesn't make much sense)