### PR TITLE
Swap to urlopen to respect proxies

### DIFF
--- a/telescope/__main__.py
+++ b/telescope/__main__.py
@@ -4,9 +4,11 @@ import json
 import logging
 import multiprocessing
 import os
+import shutil
+import urllib
 from datetime import datetime
 from functools import partial
-from urllib.request import urlretrieve
+from urllib.request import urlopen
 
 import click as click
 from click import Path, echo
@@ -165,7 +167,8 @@ def cli(
             data["cluster_info"] = {"error": str(e)}
 
         if AIRGAPPED:
-            urlretrieve(REPORT_PACKAGE_URL, REPORT_PACKAGE)
+            with urllib.request.urlopen(REPORT_PACKAGE_URL) as response, open(REPORT_PACKAGE, "wb") as out_file:
+                shutil.copyfileobj(response, out_file)
 
     # get all the Airflow Reports at once, in parallel
     spinner = Halo(


### PR DESCRIPTION
@nsastro - can't add you as a reviewer but if you can help me test + verify this work it would be appreciated.

This work was required because some organizations utilize `http_proxy` variables on their workstations, and were unable to utilize the `AIRGAP` feature flags. Apparently `urlopen` respects proxies, while `urlretrieve` is a legacy method that requires more magic to do so. Hard to tell exactly from the docs ...

https://docs.python.org/3/library/urllib.request.html#urllib.request.urlopen

> In addition, if proxy settings are detected (for example, when a *_proxy environment variable like http_proxy is set), [ProxyHandler](https://docs.python.org/3/library/urllib.request.html#urllib.request.ProxyHandler) is default installed and makes sure the requests are handled through the proxy.