### PR TITLE
Return results correctly for local/ssh

### DIFF
--- a/telescope/getters/local.py
+++ b/telescope/getters/local.py
@@ -25,7 +25,7 @@ class LocalGetter(Getter):
         elif out.stderr is not None:
             out = out.stderr
         else:
-            out = "Unknown Error"
+            raise RuntimeError("Unknown Error")
         return out
 
     def get_report_key(self):


### PR DESCRIPTION
Both `--local` and `ssh` modes utilize Fabric / Invoke. 
Fabric was returning a `Result` object, resulting in an `unpickleable` exception being thrown

<img width="1318" alt="image" src="https://user-images.githubusercontent.com/80706212/173418793-6e66c939-5c78-47b8-9c0d-b408a3107f33.png">