### PR TITLE
Update README.md to include direct link that is requirements.txt compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ source venv/bin/activate
 Install Telescope using Pip from Github
 
 ```shell
-python -m pip install telescope --find-links https://github.com/astronomer/telescope/releases/latest
+pip install git+https://github.com/astronomer/telescope.git
 ```
 
 # Quickstart - Kubernetes Autodiscovery Assessment Mode


### PR DESCRIPTION
`✗ pip install git+https://github.com/astronomer/telescope.git`

Works with `requirements.txt` via `pip install -r requirements.txt`

This will pull from the latest commit on `main` though