### PR TITLE
Remove Verify and Kubernetes Helm Fixes

### DIFF
--- a/astronomer_telescope/__main__.py
+++ b/astronomer_telescope/__main__.py
@@ -144,11 +144,6 @@ def cli(
 
     # Check for helm secrets or get cluster info if we know we are running with Kubernetes
     if any(type(g) == KubernetesGetter for g in all_getters):
-        helm_spinner = Halo(
-            text="Verifying helm chart info",
-            spinner="dots",
-        )
-        helm_spinner.start()
         cluster_spinner = Halo(
             text="Gathering cluster info",
             spinner="dots",

--- a/astronomer_telescope/__main__.py
+++ b/astronomer_telescope/__main__.py
@@ -149,16 +149,6 @@ def cli(
             spinner="dots",
         )
         helm_spinner.start()
-        # Feature gate "verify"
-        if os.getenv("TELESCOPE_SHOULD_VERIFY", True):
-            try:
-                data["verify"] = get_helm_info()
-                helm_spinner.succeed()
-            except Exception as e:
-                helm_spinner.warn("verifying helm info failed")
-                log.debug(e)
-                data["verify"] = {"error": str(e)}
-
         cluster_spinner = Halo(
             text="Gathering cluster info",
             spinner="dots",

--- a/astronomer_telescope/functions/astronomer_enterprise.py
+++ b/astronomer_telescope/functions/astronomer_enterprise.py
@@ -56,7 +56,14 @@ def get_helm_info(namespace: Optional[str] = None):
                         ["registry", "connection", "pass"],
                         ["webserver", "defaultUser", "password"],
                     ]:
-                        deep_clean(v, helm_contents["chart"]["values"])
+                        try:
+                            deep_clean(v, helm_contents["chart"]["values"])
+                        except Exception as e:
+                            log.debug(e)
+                        try:
+                            deep_clean(v, helm_contents["config"]["airflow"])
+                        except Exception as e:
+                            log.debug(e)
                 except Exception as e:
                     log.exception(e)
                 output[namespace] = {
@@ -64,6 +71,7 @@ def get_helm_info(namespace: Optional[str] = None):
                     "last_deployed": helm_contents["info"]["last_deployed"],
                     "chart_metadata": helm_contents["chart"]["metadata"],
                     "chart_values": helm_contents["chart"]["values"],
+                    "config": helm_contents["config"],
                 }
         except Exception as e:
             log.debug(e)

--- a/astronomer_telescope/functions/astronomer_enterprise.py
+++ b/astronomer_telescope/functions/astronomer_enterprise.py
@@ -43,8 +43,9 @@ def get_helm_info(namespace: Optional[str] = None):
                 ).decode()
             )
             # filter to only astronomer/airflow helm charts and only the most recent version
-            if helm_contents["info"]["status"] == "deployed" or any(
-                [word in helm_contents["chart"]["metadata"]["name"] for word in ["astronomer", "airflow"]]
+            if helm_contents["info"]["status"] == "deployed" and (
+                "astronomer" in helm_contents["chart"]["metadata"]["name"]
+                or "airflow" in helm_contents["chart"]["metadata"]["name"]
             ):
                 try:
                     for v in [


### PR DESCRIPTION
- Removed the top level verify
- Attached the `config` value from the helm chart secret in the Airflow namespace for Kubernetes execution, this is the correct source of things like the number of Airflow Schedulers