### PR TITLE
Allow setting the Report Package download URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ fileloc="/a/b/c/d/filepath.py" -> "th.py"
 - `TELESCOPE_KUBERNETES_AIRGAPPED=true` - executes the airflow report in airgapped mode (i.e copies report binary from local to pod)
 - `LOG_LEVEL=DEBUG` - can be any support Python logging level `[CRITICAL, FATAL, ERROR, WARN, WARNING, INFO, DEBUG, NOTSET]`
 - `TELESCOPE_SHOULD_VERIFY=false` - turn off helm chart collection - required to gather some data about Airflow in Kubernetes
+- `TELESCOPE_REPORT_PACKAGE_URL` - sets the URL that both the local CLI AND `TELESCOPE_AIRFLOW_REMOTE_CMD` will use (unless `TELESCOPE_AIRFLOW_REMOTE_CMD` is set directly)
 
 # Alternative Methods 
 Telescope can also be installed as an Airflow plugin and has an `AeroscopeOperator` 

--- a/astronomer_telescope/config.py
+++ b/astronomer_telescope/config.py
@@ -6,4 +6,4 @@ import astronomer_telescope
 VERSION = os.getenv("TELESCOPE_REPORT_RELEASE_VERSION", astronomer_telescope.version)
 AIRGAPPED = os.getenv("TELESCOPE_KUBERNETES_AIRGAPPED", "false").lower() == "true"
 REPORT_PACKAGE = "airflow_report.pyz"
-REPORT_PACKAGE_URL = f"https://github.com/astronomer/telescope/releases/download/v{VERSION}/{REPORT_PACKAGE}"
+REPORT_PACKAGE_URL = os.getenv("TELESCOPE_REPORT_PACKAGE_URL", f"https://github.com/astronomer/telescope/releases/download/v{VERSION}/{REPORT_PACKAGE}")


### PR DESCRIPTION
Allow users to set an internal download URL for the Airflow Report package.

```
TELESCOPE_REPORT_PACKAGE_URL=https://some.package/url
```

Fixes #191