### PR TITLE
set license filename in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "astronomer-telescope"
 dynamic = ["version"]
 description = "A tool to observe distant (or local!) Airflow installations, and gather metadata or other required data."
 readme = "README.md"
+license = {file = "LICENSE"}
 authors = [
     { name = "Fritz Davenport", email = "fritz@astronomer.io" },
     { name = "CETA Team", email = "ceta@astronomer.io" },


### PR DESCRIPTION
We have a customer that claims we aren't specifying a license. Appeared to build successfully, unsure of efficacy. Syntax taken from https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license .